### PR TITLE
Add fill missing intervals for TS.RANGE

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -46,4 +46,5 @@ type queryModel struct {
 	Legend      string `json:"legend"`
 	Value       string `json:"value"`
 	Section     string `json:"section"`
+	Fill        bool   `json:"fill"`
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -17,7 +17,7 @@ import { RedisDataSourceOptions } from '../types';
 /**
  * Form Field
  */
-const { FormField } = LegacyForms;
+const { FormField, Switch } = LegacyForms;
 
 /**
  * Editor Property
@@ -147,8 +147,21 @@ export class QueryEditor extends PureComponent<Props> {
    * Render Editor
    */
   render() {
-    const { key, aggregation, bucket, legend, command, field, filter, value, query, type, section } = this.props.query;
-    const { onRunQuery } = this.props;
+    const {
+      key,
+      aggregation,
+      bucket,
+      legend,
+      command,
+      field,
+      filter,
+      value,
+      query,
+      type,
+      section,
+      fill,
+    } = this.props.query;
+    const { onRunQuery, onChange } = this.props;
 
     /**
      * Return
@@ -268,6 +281,9 @@ export class QueryEditor extends PureComponent<Props> {
           <div className="gf-form">
             <InlineFormLabel width={8}>Aggregation</InlineFormLabel>
             <Select
+              className={css`
+                margin-right: 5px;
+              `}
               options={Aggregations}
               width={30}
               onChange={this.onAggregationTextChange}
@@ -282,6 +298,17 @@ export class QueryEditor extends PureComponent<Props> {
                 onChange={this.onBucketTextChange}
                 label="Bucket"
                 tooltip="Time bucket for aggregation in milliseconds"
+              />
+            )}
+            {aggregation && bucket && CommandParameters.fill.includes(command) && (
+              <Switch
+                label="Fill Missing"
+                labelClass="width-10"
+                tooltip="If checked, the datasource will fill missing intervals."
+                checked={fill || false}
+                onChange={(event) => {
+                  onChange({ ...this.props.query, fill: event.currentTarget.checked });
+                }}
               />
             )}
           </div>

--- a/src/redis/command.ts
+++ b/src/redis/command.ts
@@ -106,4 +106,5 @@ export const CommandParameters = {
   legendLabel: ['ts.mrange'],
   section: ['info'],
   valueLabel: ['ts.mrange'],
+  fill: ['ts.range'],
 };

--- a/src/redis/query.ts
+++ b/src/redis/query.ts
@@ -100,6 +100,13 @@ export interface RedisQuery extends DataQuery {
   bucket?: string;
 
   /**
+   * Fill
+   *
+   * @type {boolean}
+   */
+  fill?: boolean;
+
+  /**
    * Legend label
    *
    * @type {string}


### PR DESCRIPTION
Fill missing intervals implemented in the datasource when Aggregation and Bucket specified for TS.RANGE command.
Resolve #50.  

![Screen Shot 2020-08-22 at 2 05 43 PM](https://user-images.githubusercontent.com/47795110/90965830-97167680-e480-11ea-9feb-30b1dbbf417b.png)