### PR TITLE
Update Key to KeyName to avoid conflict in the Explore tab

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -47,7 +47,7 @@ type dataModel struct {
 type queryModel struct {
 	Type        string `json:"type"`
 	Query       string `json:"query"`
-	Key         string `json:"key"`
+	Key         string `json:"keyName"`
 	Field       string `json:"field"`
 	Filter      string `json:"filter"`
 	Command     string `json:"command"`

--- a/src/components/query-editor.test.tsx
+++ b/src/components/query-editor.test.tsx
@@ -7,7 +7,7 @@ import { AggregationValue, InfoSectionValue, QueryTypeValue, RedisQuery } from '
  * Query
  */
 const getQuery = (overrideQuery: object = {}): RedisQuery => ({
-  key: '',
+  keyName: '',
   aggregation: AggregationValue.NONE,
   bucket: 0,
   legend: '',
@@ -219,12 +219,12 @@ describe('QueryEditor', () => {
       });
 
       it('Should set value from query', () => {
-        const query = getQuery({ type: QueryTypeValue.COMMAND, command: 'get', key: '123' });
+        const query = getQuery({ type: QueryTypeValue.COMMAND, command: 'get', keyName: '123' });
         const wrapper = shallow<QueryEditor>(
           <QueryEditor datasource={{} as any} query={query} onRunQuery={onRunQuery} onChange={onChange} />
         );
         const testedComponent = getComponent(wrapper);
-        expect(testedComponent.prop('value')).toEqual(query.key);
+        expect(testedComponent.prop('value')).toEqual(query.keyName);
       });
 
       it('Should call onKeyChange method when onChange prop was called', () => {
@@ -232,7 +232,7 @@ describe('QueryEditor', () => {
         const wrapper = shallow<QueryEditor>(
           <QueryEditor datasource={{} as any} query={query} onRunQuery={onRunQuery} onChange={onChange} />
         );
-        const testedMethod = jest.spyOn(wrapper.instance(), 'onKeyChange');
+        const testedMethod = jest.spyOn(wrapper.instance(), 'onKeyNameChange');
         wrapper.instance().forceUpdate();
         const testedComponent = getComponent(wrapper);
         const newValue = '1234';
@@ -240,7 +240,7 @@ describe('QueryEditor', () => {
         expect(testedMethod).toHaveBeenCalledWith({ target: { value: newValue } });
         expect(onChange).toHaveBeenCalledWith({
           ...query,
-          key: newValue,
+          keyName: newValue,
         });
       });
     });

--- a/src/components/query-editor.tsx
+++ b/src/components/query-editor.tsx
@@ -31,13 +31,13 @@ type Props = QueryEditorProps<DataSource, RedisQuery, RedisDataSourceOptions>;
  */
 export class QueryEditor extends PureComponent<Props> {
   /**
-   * Key change
+   * Key name change
    *
    * @param {ChangeEvent<HTMLInputElement>} event Event
    */
-  onKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
+  onKeyNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onChange, query } = this.props;
-    onChange({ ...query, key: event.target.value });
+    onChange({ ...query, keyName: event.target.value });
   };
 
   /**
@@ -150,7 +150,7 @@ export class QueryEditor extends PureComponent<Props> {
    */
   render() {
     const {
-      key,
+      keyName,
       aggregation,
       bucket,
       legend,
@@ -204,12 +204,12 @@ export class QueryEditor extends PureComponent<Props> {
 
         {type !== QueryTypeValue.CLI && command && (
           <div className="gf-form">
-            {CommandParameters.key.includes(command) && (
+            {CommandParameters.keyName.includes(command) && (
               <FormField
                 labelWidth={8}
                 inputWidth={30}
-                value={key}
-                onChange={this.onKeyChange}
+                value={keyName}
+                onChange={this.onKeyNameChange}
                 label="Key"
                 tooltip="Key name"
               />

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -75,7 +75,7 @@ export class DataSource extends DataSourceWithBackend<RedisQuery, RedisDataSourc
      */
     return {
       ...query,
-      key: query.key ? templateSrv.replace(query.key, scopedVars) : '',
+      keyName: query.keyName ? templateSrv.replace(query.keyName, scopedVars) : '',
       query: query.query ? templateSrv.replace(query.query, scopedVars) : '',
       field: query.field ? templateSrv.replace(query.field, scopedVars) : '',
       filter: query.filter ? templateSrv.replace(query.filter, scopedVars) : '',

--- a/src/redis/command.ts
+++ b/src/redis/command.ts
@@ -103,7 +103,7 @@ export const CommandParameters = {
   aggregation: ['ts.range', 'ts.mrange'],
   field: ['hget','hmget'],
   filter: ['ts.mrange', 'ts.queryindex'],
-  key: [
+  keyName: [
     'get',
     'hget',
     'hgetall',

--- a/src/redis/query.ts
+++ b/src/redis/query.ts
@@ -83,7 +83,7 @@ export interface RedisQuery extends DataQuery {
    *
    * @type {string}
    */
-  key?: string;
+  keyName?: string;
 
   /**
    * Value label


### PR DESCRIPTION
`Key` is reserved in the Explore tab and the Redis command with `key` input are not working.
BREAKING change.

Resolves #87 