### PR TITLE
Remove "Unknown command" error from response for custom panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "name": "redis-datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build --coverage",
-    "build:backend": "mage -v lint && mage -v",
+    "build:backend": "mage -v lint && mage cover && mage -v",
     "dev": "grafana-toolkit plugin:dev",
     "format": "prettier --write \"**\"",
     "start": "docker-compose up",

--- a/pkg/query.go
+++ b/pkg/query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -87,7 +86,7 @@ func (ds *redisDatasource) query(ctx context.Context, query backend.DataQuery, c
 		return ds.queryFtInfo(qm, client)
 	default:
 		response := backend.DataResponse{}
-		response.Error = fmt.Errorf("Unknown command")
+		log.DefaultLogger.Error("Query", "Command", qm.Command)
 		return response
 	}
 }

--- a/pkg/query_test.go
+++ b/pkg/query_test.go
@@ -91,7 +91,7 @@ func TestQueryWithErrors(t *testing.T) {
 			JSON:          marshaled,
 		}, client)
 
-		require.EqualError(t, response.Error, "Unknown command", "Should return unknown command error")
+		require.NoError(t, response.Error, "Should not return error")
 	})
 
 }


### PR DESCRIPTION
Custom Panels query their own command and don't need to specify anything in the Query Editor.