### PR TITLE
Fix RG.DUMPREGISTRATIONS command to accept args with array

### DIFF
--- a/pkg/redis-gears.go
+++ b/pkg/redis-gears.go
@@ -34,14 +34,14 @@ type dumpregistrations struct {
  * Registration data for RG.DUMPREGISTRATIONS Radix marshaling
  */
 type registrationData struct {
-	Mode         string            `redis:"mode"`
-	NumTriggered int64             `redis:"numTriggered"`
-	NumSuccess   int64             `redis:"numSuccess"`
-	NumFailures  int64             `redis:"numFailures"`
-	NumAborted   int64             `redis:"numAborted"`
-	LastError    string            `redis:"lastError"`
-	Args         map[string]string `redis:"args"`
-	Status       string            `redis:"status"`
+	Mode         string                 `redis:"mode"`
+	NumTriggered int64                  `redis:"numTriggered"`
+	NumSuccess   int64                  `redis:"numSuccess"`
+	NumFailures  int64                  `redis:"numFailures"`
+	NumAborted   int64                  `redis:"numAborted"`
+	LastError    string                 `redis:"lastError"`
+	Args         map[string]interface{} `redis:"args"`
+	Status       string                 `redis:"status"`
 }
 
 /**

--- a/pkg/redis-gears_test.go
+++ b/pkg/redis-gears_test.go
@@ -85,7 +85,7 @@ func TestRgDumpregistrations(t *testing.T) {
 					NumFailures:  3,
 					NumAborted:   4,
 					LastError:    "some err",
-					Args:         map[string]string{"mytrigger": "trigger"},
+					Args:         map[string]interface{}{"mytrigger": "trigger"},
 				},
 				PD: "some_pd",
 			}},


### PR DESCRIPTION
Found using one of the examples: https://oss.redislabs.com/redisgears/examples.html
```
def process(x):
    '''
    Processes a message from the local expiration stream
    Note: in this example we simply print to the log, but feel free to replace
    this logic with your own, e.g. an HTTP request to a REST API or a call to an
    external data store.
    '''
    log(f"Key '{x['value']['key']}' expired at {x['id'].split('-')[0]}")

# Capture an expiration event and adds it to the shard's local 'expired' stream
cap = GB('KeysReader')
cap.foreach(lambda x:
            execute('XADD', f'expired:{hashtag()}', '*', 'key', x['key']))
cap.register(prefix='*',
             mode='sync',
             eventTypes=['expired'],
             readValue=False)

# Consume new messages from expiration streams and process them somehow
proc = GB('StreamReader')
proc.foreach(process)
proc.register(prefix='expired:*',
              batch=100,
              duration=1)
```