### PR TITLE
[BUG] Tls client certificates not working

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mediocregopher/radix/v3 v3.7.0
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/prometheus/common v0.18.0 // indirect

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -194,6 +194,9 @@ func createRedisClientConfig(setting backend.DataSourceInstanceSettings) (redisC
 		if secureData["tlsClientCert"] != "" {
 			configuration.TLSClientCert = secureData["tlsClientCert"]
 		}
+		if secureData["tlsClientKey"] != "" {
+			configuration.TLSClientKey = secureData["tlsClientKey"]
+		}
 	}
 
 	return configuration, nil

--- a/pkg/datasource_test.go
+++ b/pkg/datasource_test.go
@@ -75,7 +75,7 @@ func TestCreateRedisClientConfig(t *testing.T) {
 				Password:       "1234",
 				TLSCACert:      "BEGIN CERTIFICATE",
 				TLSClientCert:  "BEGIN CERTIFICATE",
-				TLSClientKey: 	"BEGIN RSA PRIVATE KEY",
+				TLSClientKey:   "BEGIN RSA PRIVATE KEY",
 			},
 			"",
 		},

--- a/pkg/datasource_test.go
+++ b/pkg/datasource_test.go
@@ -62,6 +62,7 @@ func TestCreateRedisClientConfig(t *testing.T) {
 					"password":      "1234",
 					"tlsCACert":     "BEGIN CERTIFICATE",
 					"tlsClientCert": "BEGIN CERTIFICATE",
+					"tlsClientKey":  "BEGIN RSA PRIVATE KEY",
 				},
 			},
 			redisClientConfiguration{
@@ -74,6 +75,7 @@ func TestCreateRedisClientConfig(t *testing.T) {
 				Password:       "1234",
 				TLSCACert:      "BEGIN CERTIFICATE",
 				TLSClientCert:  "BEGIN CERTIFICATE",
+				TLSClientKey: 	"BEGIN RSA PRIVATE KEY",
 			},
 			"",
 		},

--- a/pkg/redis-client.go
+++ b/pkg/redis-client.go
@@ -27,6 +27,7 @@ type redisClientConfiguration struct {
 	Password       string
 	TLSCACert      string
 	TLSClientCert  string
+	TLSClientKey   string
 	SentinelName   string
 }
 
@@ -122,8 +123,8 @@ func newRadixV3Client(configuration redisClientConfiguration) (redisClient, erro
 			}
 
 			// Certificate and Key
-			if configuration.TLSClientCert != "" {
-				cert, err := tls.X509KeyPair([]byte(configuration.TLSClientCert), []byte(configuration.TLSClientCert))
+			if configuration.TLSClientCert != "" && configuration.TLSClientKey != "" {
+				cert, err := tls.X509KeyPair([]byte(configuration.TLSClientCert), []byte(configuration.TLSClientKey))
 				if err == nil {
 					tlsConfig.Certificates = []tls.Certificate{cert}
 				} else {


### PR DESCRIPTION
# Description
Our company relies on mutual authentication between redis server and clients, therefore we are unable to use the redis datasource plugin.

# Issue
X509KeyPair currently takes the cert as the argument for the keyfile.
Keyfile is not read from json.
