### PR TITLE
Add missing Time Series aggregator types

### DIFF
--- a/src/redis/time-series.ts
+++ b/src/redis/time-series.ts
@@ -55,6 +55,12 @@ export enum AggregationValue {
   MIN = 'min',
   RANGE = 'range',
   SUM = 'sum',
+  FIRST = 'first',
+  LAST = 'last',
+  STDP = 'std.p',
+  STDS = 'std.s',
+  VARP = 'var.p',
+  VARS = 'var.s',
 }
 
 /**
@@ -68,4 +74,10 @@ export const Aggregations: Array<SelectableValue<AggregationValue>> = [
   { label: 'Min', description: 'Minimum', value: AggregationValue.MIN },
   { label: 'Range', description: 'Diff between maximum and minimum in the bucket', value: AggregationValue.RANGE },
   { label: 'Sum', description: 'Summation', value: AggregationValue.SUM },
+  { label: 'First', description: 'The value with the lowest timestamp in the bucket', value: AggregationValue.FIRST },
+  { label: 'Last', description: 'The value with the highest timestamp in the bucket', value: AggregationValue.LAST },
+  { label: 'Std.p', description: 'Population standard deviation of the values', value: AggregationValue.STDP },
+  { label: 'Std.s', description: 'Sample standard deviation of the values', value: AggregationValue.STDS },
+  { label: 'Var.p', description: 'Population variance of the values', value: AggregationValue.VARP },
+  { label: 'Var.s', description: 'Sample variance of the values', value: AggregationValue.VARS },
 ];


### PR DESCRIPTION
Just noticed that some of the aggregator types are missing from the Aggregation selector.

Used this as a reference: https://redis.io/commands/ts.range/
Descriptions are taken straight from the official TS.RANGE command doc.

I've examined the code a bit and it seems like this is the only place that needs to be changed, but not 100% sure...

Thanks for an awesome plugin