### PR TITLE
handling scalars in JSON.GET

### DIFF
--- a/pkg/redis-json.go
+++ b/pkg/redis-json.go
@@ -139,7 +139,7 @@ func queryJsonGet(qm queryModel, client redisClient) backend.DataResponse {
 					case float64:
 						fields[i] = data.NewField(i, nil, []float64{})
 						for j := 0; j < rowscount-1; j++ {
-							fields[i].Append(0)
+							fields[i].Append(float64(0))
 						}
 					}
 					frame.Fields = append(frame.Fields, fields[i])

--- a/pkg/redis-json.go
+++ b/pkg/redis-json.go
@@ -122,16 +122,27 @@ func queryJsonGet(qm queryModel, client redisClient) backend.DataResponse {
 
 			// Value
 			switch e := entry.(type) {
-			case string:
+			case string, bool, float64:
 				i := "Value"
 				if _, ok := fields[i]; !ok {
-					fields[i] = data.NewField(i, nil, []string{})
-					frame.Fields = append(frame.Fields, fields[i])
-
-					// Generate empty values for all previous rows
-					for j := 0; j < rowscount-1; j++ {
-						fields[i].Append("")
+					switch entry.(type) {
+					case string:
+						fields[i] = data.NewField(i, nil, []string{})
+						for j := 0; j < rowscount-1; j++ {
+							fields[i].Append("")
+						}
+					case bool:
+						fields[i] = data.NewField(i, nil, []bool{})
+						for j := 0; j < rowscount-1; j++ {
+							fields[i].Append(false)
+						}
+					case float64:
+						fields[i] = data.NewField(i, nil, []float64{})
+						for j := 0; j < rowscount-1; j++ {
+							fields[i].Append(0)
+						}
 					}
+					frame.Fields = append(frame.Fields, fields[i])
 				}
 
 				// Insert value for current row

--- a/pkg/redis-json_test.go
+++ b/pkg/redis-json_test.go
@@ -2,24 +2,11 @@ package main
 
 import (
 	"errors"
-	"fmt"
-	"github.com/mediocregopher/radix/v3"
 	"testing"
 
 	"github.com/redisgrafana/grafana-redis-datasource/pkg/models"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQueryGetNumber(t *testing.T) {
-	// Client
-	radixClient, _ := radix.NewPool("tcp", fmt.Sprintf("%s:%d", "localhost", 6379), 10)
-	client := radixV3Impl{radixClient: radixClient}
-
-	qm := queryModel{Command: "JSON.GET", Key: "test:2", Path: "$.age"}
-
-	queryJsonGet(qm, &client)
-
-}
 
 /**
  * Type and Length commands with Key and Path

--- a/pkg/redis-json_test.go
+++ b/pkg/redis-json_test.go
@@ -160,6 +160,55 @@ func TestQueryJsonObjKeys(t *testing.T) {
 func TestQueryJsonGet(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should return four strings in frame", func(t *testing.T) {
+		t.Parallel()
+
+		client := testClient{rcv: "[[],\"gin\",\"rum\",\"whiskey\"]"}
+
+		resp := queryJsonGet(queryModel{Command: models.JsonGet, Key: "test:json", Path: "$.num"}, &client)
+
+		require.Len(t, resp.Frames, 1)
+		require.Len(t, resp.Frames[0].Fields, 1)
+		require.Equal(t, resp.Frames[0].Fields[0].Len(), 4)
+		require.Equal(t, resp.Frames[0].Fields[0].At(0), "")
+		require.Equal(t, resp.Frames[0].Fields[0].At(1), "gin")
+		require.Equal(t, resp.Frames[0].Fields[0].At(2), "rum")
+		require.Equal(t, resp.Frames[0].Fields[0].At(3), "whiskey")
+	})
+
+	t.Run("Should return four booleans in frame", func(t *testing.T) {
+		t.Parallel()
+
+		client := testClient{rcv: "[[],true,false,true]"}
+
+		resp := queryJsonGet(queryModel{Command: models.JsonGet, Key: "test:json", Path: "$.num"}, &client)
+
+		require.Len(t, resp.Frames, 1)
+		require.Len(t, resp.Frames[0].Fields, 1)
+		require.Equal(t, resp.Frames[0].Fields[0].Len(), 4)
+		require.Equal(t, resp.Frames[0].Fields[0].At(0), false)
+		require.Equal(t, resp.Frames[0].Fields[0].At(1), true)
+		require.Equal(t, resp.Frames[0].Fields[0].At(2), false)
+		require.Equal(t, resp.Frames[0].Fields[0].At(3), true)
+	})
+
+	t.Run("Should return four float64 in frame", func(t *testing.T) {
+		t.Parallel()
+
+		client := testClient{rcv: "[[],42,43,44]"}
+
+		resp := queryJsonGet(queryModel{Command: models.JsonGet, Key: "test:json", Path: "$.num"}, &client)
+
+		require.Len(t, resp.Frames, 1)
+		require.Len(t, resp.Frames[0].Fields, 1)
+		require.Equal(t, resp.Frames[0].Fields[0].Len(), 4)
+		require.Equal(t, resp.Frames[0].Fields[0].At(0), float64(0))
+		require.Equal(t, resp.Frames[0].Fields[0].At(1), float64(42))
+		require.Equal(t, resp.Frames[0].Fields[0].At(2), float64(43))
+		require.Equal(t, resp.Frames[0].Fields[0].At(3), float64(44))
+
+	})
+
 	t.Run("Should return a single float64 in frame", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Fixes #283 - adds support for scalar types beyond strings (booleans and numbers)