### PR TITLE
ci: install dependencies unconditionally instead of skipping on a cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,34 +13,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache
-        uses: actions/cache@v4
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile;
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-engines
 
       - name: Build and test frontend
         run: yarn build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,34 +17,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache
-        uses: actions/cache@v4
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile;
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-engines
 
       - name: Build and test frontend
         run: yarn build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,34 +16,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache
-        uses: actions/cache@v4
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile;
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-engines
 
       - name: Build and test frontend
         run: yarn build


### PR DESCRIPTION
Fixes #343.

The three workflows cache `node_modules` and skip `yarn install` whenever both caches hit, so a run that restores the cache never resolves `yarn.lock` and reports success on dependencies it did not install. `--frozen-lockfile` is the check being skipped. Because GitHub evicts a cache after seven days without a read and a fresh fork has none, the same commit is green on one runner and red on another.

This removes the two `actions/cache` steps, lets `actions/setup-node` cache the yarn download directory with `cache: yarn`, and runs the install unconditionally:

```yaml
      - name: Setup Node.js environment
        uses: actions/setup-node@v4
        with:
          node-version: "20.x"
          cache: yarn

      - name: Install dependencies
        run: yarn install --frozen-lockfile --ignore-engines
```

The install now always validates the lockfile, and the download cache still removes most of the network cost. Deleting the `node_modules` cache step also removes the dead `matrix.node-version` segment in its key, which was always empty because the job declares no matrix.

### Why `--ignore-engines` is in there

Running the install on a cold runner is how I found that `master` does not install on Node 20 at all:

```
error eslint-plugin-jsdoc@37.0.3: The engine "node" is incompatible with this module.
Expected version "^12 || ^14 || ^16 || ^17". Got "20.20.2"
error Found incompatible module.
```

`eslint-plugin-jsdoc@37.0.3` arrives through `@grafana/toolkit@8.3.4` and declares an `engines.node` range that stops at Node 17. Yarn 1 enforces `engines` and fails the install. Node was raised to `20.x` in #341, and every run since has skipped the install on a warm cache, so nothing surfaced it.

With `--ignore-engines` the install completes and `yarn build` — lint, tests and compile — passes on Node 20. I ran the current `master` tree in a `node:20` container to confirm both halves:

| Step | Result |
|---|---|
| `yarn install --frozen-lockfile` | fails, incompatible engine |
| `yarn install --frozen-lockfile --ignore-engines` | exit 0 |
| `NODE_OPTIONS=--openssl-legacy-provider yarn build` | exit 0, 229 tests pass |

The flag is a stopgap, not a fix for the underlying dependency: the honest resolution is replacing `@grafana/toolkit`, which has been deprecated in favour of `@grafana/create-plugin`. That is a much larger change and does not belong in this pull request. If you would rather not carry the flag, the alternative is pinning Node back to 16, which is long out of support.

### Scope

Same change in `ci.yml`, `main.yml` and `integration.yml`. `actionlint` reports 19 findings on `master` and 10 with this branch; the rest are `::set-output` uses, which the sibling pull request handles. The two branches touch different lines and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113756bSk1mrhwvk4y4dTBw
