### PR TITLE
ci: write step outputs to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "::set-output name=has-backend::true"
+            echo "has-backend=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go environment

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "::set-output name=has-backend::true"
+            echo "has-backend=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "::set-output name=has-backend::true"
+            echo "has-backend=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go environment
@@ -94,19 +94,20 @@ jobs:
           export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
           export GRAFANA_PLUGIN_ARTIFACT_CHECKSUM=${GRAFANA_PLUGIN_ARTIFACT}.md5
 
-          echo "::set-output name=plugin-id::${GRAFANA_PLUGIN_ID}"
-          echo "::set-output name=plugin-version::${GRAFANA_PLUGIN_VERSION}"
-          echo "::set-output name=plugin-type::${GRAFANA_PLUGIN_TYPE}"
-          echo "::set-output name=archive::${GRAFANA_PLUGIN_ARTIFACT}"
-          echo "::set-output name=archive-checksum::${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}"
-
-          echo ::set-output name=github-tag::${GITHUB_REF#refs/*/}
+          {
+            echo "plugin-id=${GRAFANA_PLUGIN_ID}"
+            echo "plugin-version=${GRAFANA_PLUGIN_VERSION}"
+            echo "plugin-type=${GRAFANA_PLUGIN_TYPE}"
+            echo "archive=${GRAFANA_PLUGIN_ARTIFACT}"
+            echo "archive-checksum=${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}"
+            echo "github-tag=${GITHUB_REF#refs/*/}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Read changelog
         id: changelog
         run: |
           awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
-          echo "::set-output name=path::release_notes.md"
+          echo "path=release_notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Check package version
         run: if [ "v${{ steps.metadata.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name\033[0m\n"; exit 1; fi
@@ -117,7 +118,7 @@ jobs:
           mv dist ${{ steps.metadata.outputs.plugin-id }}
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
           md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
-          echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
+          echo "checksum=$(cut -d' ' -f1 < ./${{ steps.metadata.outputs.archive-checksum }})" >> "$GITHUB_OUTPUT"
 
       - name: Lint plugin
         continue-on-error: true


### PR DESCRIPTION
Part of #343.

`::set-output` was deprecated in October 2022 and replaced by `$GITHUB_OUTPUT`. Every run that uses it logs a deprecation warning. To be accurate about the urgency: the removal was scheduled for June 2023 and then postponed indefinitely, so nothing is breaking today. This is warning noise and a command GitHub no longer intends to keep, not a deadline. `main.yml` depends on it for the whole `metadata` step, which is the part that would hurt if the removal ever lands.

This converts the remaining uses: `has-backend` in all three workflows, and the `metadata`, `changelog` and `package-plugin` steps in `main.yml`. The multi-line metadata block is grouped so the redirection is written once:

```yaml
          {
            echo "plugin-id=${GRAFANA_PLUGIN_ID}"
            ...
          } >> "$GITHUB_OUTPUT"
```

The checksum line loses a useless `cat`, which is also the `SC2086` that `actionlint` flagged there.

One `::set-output` is deliberately left alone, in the `Get yarn cache directory path` step. The sibling pull request for #343 deletes that step outright, and leaving it here keeps the two branches on disjoint lines so they merge cleanly in either order.

Note on CI: this branch keeps the cache-hit guard on the install, so on a runner with a cold cache it fails at `yarn install --frozen-lockfile` for the reason described in #343 — `eslint-plugin-jsdoc@37.0.3` declares an `engines.node` range that stops at Node 17. That failure is pre-existing on `master` and is what #344 addresses; it is unrelated to the change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113756bSk1mrhwvk4y4dTBw


